### PR TITLE
issue-25 change from tryCatchThrowable to tryCatchNonFatal

### DIFF
--- a/src/main/scala/org/dynamite/crypto/HashFunctions.scala
+++ b/src/main/scala/org/dynamite/crypto/HashFunctions.scala
@@ -15,15 +15,15 @@ private[dynamite] object HashFunctions {
       algorithm <- "HmacSHA256".right
       dataBytes <- getBytes(toEncode)
       secretKey <- new SecretKeySpec(key, algorithm).right
-      mac <- \/.fromTryCatchThrowable[Mac, Throwable](Mac.getInstance(algorithm)) leftMap (t => AlgorithmNotFoundError(algorithm))
-      _ <- \/.fromTryCatchThrowable[Unit, Throwable](mac.init(secretKey)) leftMap (t => InvalidSecretKeyError(secretKey))
-      result <- \/.fromTryCatchThrowable[Array[Byte], Throwable](mac.doFinal(dataBytes)) leftMap (t => NotInitializedMacError)
+      mac <- \/.fromTryCatchNonFatal[Mac](Mac.getInstance(algorithm)) leftMap (t => AlgorithmNotFoundError(algorithm))
+      _ <- \/.fromTryCatchNonFatal[Unit](mac.init(secretKey)) leftMap (t => InvalidSecretKeyError(secretKey))
+      result <- \/.fromTryCatchNonFatal[Array[Byte]](mac.doFinal(dataBytes)) leftMap (t => NotInitializedMacError)
     } yield result
 
   def sha256(toEncode: String): HashingError \/ Array[Byte] =
     for {
       algorithm <- "SHA-256".right
-      messageDigest <- \/.fromTryCatchThrowable[MessageDigest, Throwable](MessageDigest.getInstance(algorithm)) leftMap (t => AlgorithmNotFoundError(algorithm))
+      messageDigest <- \/.fromTryCatchNonFatal[MessageDigest](MessageDigest.getInstance(algorithm)) leftMap (t => AlgorithmNotFoundError(algorithm))
       toEncodeBytes <- getBytes(toEncode)
       _ <- messageDigest.update(toEncodeBytes).right
       result <- messageDigest.digest().right
@@ -31,6 +31,6 @@ private[dynamite] object HashFunctions {
 
 
   private def getBytes(toConvert: String): EncodingNotFoundError \/ Array[Byte] = {
-    \/.fromTryCatchThrowable[Array[Byte], Throwable](toConvert.getBytes("UTF-8")) leftMap (t => EncodingNotFoundError("UTF-8"))
+    \/.fromTryCatchNonFatal[Array[Byte]](toConvert.getBytes("UTF-8")) leftMap (t => EncodingNotFoundError("UTF-8"))
   }
 }

--- a/src/main/scala/org/dynamite/dsl/requests.scala
+++ b/src/main/scala/org/dynamite/dsl/requests.scala
@@ -71,7 +71,7 @@ private[dynamite] object GetItemRequest {
       (for {
         json <- toJson(getItemRequest).right
         renderedJson <- render(json).right
-        body <- \/.fromTryCatchThrowable[String, Throwable](compact(renderedJson))
+        body <- \/.fromTryCatchNonFatal[String](compact(renderedJson))
       } yield RequestBody(body)) leftMap (e => JsonSerialisationError)
     }
   }
@@ -117,14 +117,14 @@ private[dynamite] object PutItemRequest {
       (for {
         json <- toJson(putItemRequest)
         renderedJson <- render(json).right
-        body <- \/.fromTryCatchThrowable[String, Throwable](compact(renderedJson))
+        body <- \/.fromTryCatchNonFatal[String](compact(renderedJson))
       } yield RequestBody(body)) leftMap (e => JsonSerialisationError)
     }
   }
 
   private def toJson[A](request: PutItemRequest[A])(implicit formats: Formats): DynamoCommonError \/ JValue = {
     (for {
-      item <- \/.fromTryCatchThrowable[JValue, Throwable](decompose(request.item))
+      item <- \/.fromTryCatchNonFatal[JValue](decompose(request.item))
     } yield {
       ("Item" -> AwsJsonWriter.toAws(item)) ~
         ("ConditionExpression" -> request.conditionExpression) ~

--- a/src/main/scala/org/dynamite/http/RequestParser.scala
+++ b/src/main/scala/org/dynamite/http/RequestParser.scala
@@ -11,14 +11,14 @@ private[dynamite] object RequestParser {
   implicit private val formats = DefaultFormats + new AwsErrorSerializer
 
   def parse(jsonString: String): DynamoCommonError \/ JValue =
-    \/.fromTryCatchThrowable[JValue, Throwable](jparse(jsonString)) leftMap {
+    \/.fromTryCatchNonFatal[JValue](jparse(jsonString)) leftMap {
       _: Throwable =>
         //todo: add proper debug log here
         JsonDeserialisationError(s"The json $jsonString is not a valid string and was impossible to parse.")
     }
 
   def parseTo[A](jsonString: String)(implicit mf: scala.reflect.Manifest[A]): DynamoCommonError \/ A =
-    \/.fromTryCatchThrowable[A, Throwable](jparse(jsonString).extract[A]) leftMap {
+    \/.fromTryCatchNonFatal[A](jparse(jsonString).extract[A]) leftMap {
       t: Throwable =>
         //todo: add proper debug log here
         println(t)
@@ -28,7 +28,7 @@ private[dynamite] object RequestParser {
 
 private[dynamite] object RequestExtractor {
   def extract(resp: Response): DynamoCommonError \/ String =
-    \/.fromTryCatchThrowable[String, Throwable](resp.getResponseBody) leftMap {
+    \/.fromTryCatchNonFatal[String](resp.getResponseBody) leftMap {
       _: Throwable =>
         //todo: add proper debug log here
         JsonDeserialisationError("An error occurred while trying to read response from DynamoDB")


### PR DESCRIPTION
fixes #25 

In order to catch only exceptions that are recoverable, it is safer to use `tryCatchNonFatal` than `tryCatchThrowable`